### PR TITLE
Update file to new address for RadioID

### DIFF
--- a/usr/local/sbin/DMRIDUpdate.sh
+++ b/usr/local/sbin/DMRIDUpdate.sh
@@ -94,7 +94,7 @@ then
 fi
 
 # Generate new file
-curl -s -N "https://www.radioid.net/api/dmr/user/?id=%" | jq -r '.results[] | [.id, .callsign, .fname] | @csv' | sed -e 's/"//g' | sed -e 's/,/ /g' > ${DMRIDFILE}
+curl -s -N "https://database.radioid.net/api/dmr/user/?id=%" | jq -r '.results[] | [.id, .callsign, .fname] | @csv' | sed -e 's/"//g' | sed -e 's/,/ /g' > ${DMRIDFILE}
 
 # Restart YSF2DMR & mmdmvhost
 #eval ${RESTARTCOMMAND2}

--- a/usr/local/sbin/DMRIDUpdateBM.sh
+++ b/usr/local/sbin/DMRIDUpdateBM.sh
@@ -96,7 +96,7 @@ then
 fi
 
 # Generate new file
-curl -s -N "https://www.radioid.net/api/dmr/user/?id=%" | jq -r '.results[] | [.id, .callsign, .fname] | @csv' | sed -e 's/"//g' > ${DMRIDFILE}
+curl -s -N "https://database.radioid.net/api/dmr/user/?id=%" | jq -r '.results[] | [.id, .callsign, .fname] | @csv' | sed -e 's/"//g' > ${DMRIDFILE}
 
 # Restart MMDVMHost
 eval ${RESTARTCOMMAND}

--- a/usr/local/sbin/HBIDUpdate.sh
+++ b/usr/local/sbin/HBIDUpdate.sh
@@ -6,6 +6,6 @@
 #                                                 #
 ###################################################
 
-curl -s -N https://www.radioid.net/api/dmr/user/?id=% | jq -r '.results[] | [.id, .callsign, .fname] | @csv' | sed -e 's/"//g' > /var/lib/dvswitch/subscriber_ids.csv
+curl -s -N https://database.radioid.net/api/dmr/user/?id=% | jq -r '.results[] | [.id, .callsign, .fname] | @csv' | sed -e 's/"//g' > /var/lib/dvswitch/subscriber_ids.csv
 
-curl -s -N https://www.radioid.net/static/rptrids_simple_cbridge.csv | sed 's/- //g' | sed 's/,.*//g' | sed -r 's/([a-zA-Z0-9]+) ([a-zA-Z0-9]+)/\2 \1/g' > /var/lib/dvswitch/peer_ids.csv
+curl -s -N https://database.radioid.net/static/cbridge_simple_rptr.csv | sed 's/- //g' | sed 's/,.*//g' | sed -r 's/([a-zA-Z0-9]+) ([a-zA-Z0-9]+)/\2 \1/g' > /var/lib/dvswitch/peer_ids.csv

--- a/usr/local/sbin/NXDNIDUpdate.sh
+++ b/usr/local/sbin/NXDNIDUpdate.sh
@@ -6,4 +6,4 @@
 #                                                 #
 ###################################################
 
-curl -s -N https://www.radioid.net/api/nxdn/user/?id=% | jq -r '.results[] | [.id, .callsign, .fname] | @csv' | sed -e 's/"//g' > /var/lib/mmdvm/nxdn.csv
+curl -s -N https://database.radioid.net/api/nxdn/user/?id=% | jq -r '.results[] | [.id, .callsign, .fname] | @csv' | sed -e 's/"//g' > /var/lib/mmdvm/nxdn.csv


### PR DESCRIPTION
RadioID no longer uses the subdomain www for downloading the user ID data, now uses database.radioid.net

This changes the four DMR ID Update scripts to pull the information correctly.

This should fix https://github.com/DVSwitch/DVSwitch_Base/issues/1
